### PR TITLE
feat: add AppendBuffer implementation.

### DIFF
--- a/broker/Cargo.toml
+++ b/broker/Cargo.toml
@@ -8,6 +8,7 @@ resolver = "2"
 protocol = { path = "../protocol" }
 
 async-stream = "=0.3"
+async-trait = "=0.1"
 bytes = "=1"
 thiserror = "=1"
 tokio = { version = "=1", features = ["full"] }
@@ -16,3 +17,4 @@ tokio-util = { version = "=0.6", features = ["io"] }
 tonic = "=0.6"
 tracing = "=0.1"
 tracing-subscriber = "=0.3"
+tempfile = "=3"

--- a/broker/src/client/append_service.rs
+++ b/broker/src/client/append_service.rs
@@ -1,0 +1,231 @@
+use std::io::prelude::*;
+use std::io::{BufWriter, SeekFrom};
+
+use tokio::sync::{mpsc, oneshot};
+
+use crate::client::appender::StreamSection;
+use crate::client::errors::{ClientError, ClientResult};
+
+const APPEND_BUFFER_SIZE: usize = 8 * 1024; // 8KB
+
+#[derive(Debug)]
+struct AppendBuffer;
+
+impl AppendBuffer {
+    pub async fn init() -> ClientResult<AppendBufferHandle> {
+        // TODO: named temp files have some security concerns (see docs), should they be written outside of temp directories?
+        let file = tempfile::NamedTempFile::new()?;
+        let (req_tx, req_rx) = mpsc::channel::<AppendBufferReq>(1);
+        tokio::spawn(Self::handle_requests(file, req_rx));
+        Ok(AppendBufferHandle { req_tx })
+    }
+
+    async fn handle_requests(
+        file: tempfile::NamedTempFile,
+        mut req_rx: mpsc::Receiver<AppendBufferReq>,
+    ) {
+        let mut offset = 0;
+        let mut writer = std::io::BufWriter::with_capacity(APPEND_BUFFER_SIZE, file);
+        while let Some(op) = req_rx.recv().await {
+            match op {
+                AppendBufferReq::Write { res_tx, buf } => {
+                    let _ = res_tx.send(Self::write(&mut writer, &mut offset, buf));
+                }
+                AppendBufferReq::Rollback { res_tx, checkpoint } => {
+                    let _ = res_tx.send(Self::rollback(&mut writer, &mut offset, checkpoint));
+                }
+                AppendBufferReq::Read { res_tx, checkpoint } => {
+                    let _ = res_tx.send(Self::read(writer, checkpoint));
+                    break;
+                }
+            };
+        }
+    }
+
+    fn write(
+        writer: &mut BufWriter<tempfile::NamedTempFile>,
+        offset: &mut usize,
+        buf: bytes::Bytes,
+    ) -> ClientResult<AppendBufferStatus> {
+        writer.write_all(&buf)?;
+        *offset += buf.len();
+        Ok(AppendBufferStatus {
+            offset: *offset,
+            buffer_len: writer.buffer().len(),
+        })
+    }
+
+    fn rollback(
+        writer: &mut BufWriter<tempfile::NamedTempFile>,
+        offset: &mut usize,
+        checkpoint: usize,
+    ) -> ClientResult<AppendBufferStatus> {
+        *offset = checkpoint;
+        writer.seek(SeekFrom::Start(*offset as u64))?; // Flush and seek
+        Ok(AppendBufferStatus {
+            offset: *offset,
+            buffer_len: writer.buffer().len(),
+        })
+    }
+
+    fn read(
+        writer: BufWriter<tempfile::NamedTempFile>,
+        checkpoint: usize,
+    ) -> ClientResult<StreamSection<tokio_util::io::ReaderStream<tokio::fs::File>>> {
+        // TODO: handle flush error as in https://github.com/gazette/core/blob/master/broker/client/append_service.go#L453
+        let reader = writer.into_inner()?.reopen()?; // Flush buffer into File and reopen to read contents.
+        let reader = tokio::fs::File::from(reader);
+        let stream = StreamSection::new(
+            tokio_util::io::ReaderStream::with_capacity(reader, APPEND_BUFFER_SIZE),
+            checkpoint,
+        );
+        Ok(stream)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct AppendBufferHandle {
+    req_tx: mpsc::Sender<AppendBufferReq>,
+}
+
+impl AppendBufferHandle {
+    async fn write<B: Into<bytes::Bytes>>(&self, buf: B) -> ClientResult<AppendBufferStatus> {
+        let (res_tx, res_rx) = oneshot::channel::<ClientResult<AppendBufferStatus>>();
+        self.req_tx
+            .send(AppendBufferReq::Write {
+                res_tx,
+                buf: buf.into(),
+            })
+            .await?;
+        match res_rx.await {
+            Err(err) => Err(ClientError::from(err)),
+            Ok(res) => res,
+        }
+    }
+
+    async fn rollback(&self, checkpoint: usize) -> ClientResult<AppendBufferStatus> {
+        let (res_tx, res_rx) = oneshot::channel::<ClientResult<AppendBufferStatus>>();
+        self.req_tx
+            .send(AppendBufferReq::Rollback { res_tx, checkpoint })
+            .await?;
+        match res_rx.await {
+            Err(err) => Err(ClientError::from(err)),
+            Ok(res) => res,
+        }
+    }
+
+    async fn read(
+        &mut self,
+        checkpoint: usize,
+    ) -> ClientResult<StreamSection<tokio_util::io::ReaderStream<tokio::fs::File>>> {
+        let (res_tx, res_rx) = oneshot::channel::<
+            ClientResult<StreamSection<tokio_util::io::ReaderStream<tokio::fs::File>>>,
+        >();
+        self.req_tx
+            .send(AppendBufferReq::Read { res_tx, checkpoint })
+            .await?;
+        match res_rx.await {
+            Err(err) => Err(ClientError::from(err)),
+            Ok(res) => res,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum AppendBufferReq {
+    Write {
+        res_tx: oneshot::Sender<ClientResult<AppendBufferStatus>>,
+        buf: bytes::Bytes,
+    },
+    Rollback {
+        res_tx: oneshot::Sender<ClientResult<AppendBufferStatus>>,
+        checkpoint: usize,
+    },
+    Read {
+        res_tx: oneshot::Sender<
+            ClientResult<StreamSection<tokio_util::io::ReaderStream<tokio::fs::File>>>,
+        >,
+        checkpoint: usize,
+    },
+}
+
+#[derive(Debug)]
+struct AppendBufferStatus {
+    offset: usize,
+    buffer_len: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn write_and_read() {
+        let mut append_buffer = AppendBuffer::init().await.unwrap();
+
+        // write
+        let write = append_buffer.write("hello").await.unwrap();
+        assert_eq!(write.offset, 5);
+        assert_eq!(write.buffer_len, 5);
+        let write = append_buffer.write("world").await.unwrap();
+        assert_eq!(write.offset, 10);
+        assert_eq!(write.buffer_len, 10);
+
+        // read
+        let stream = append_buffer.read(write.offset).await.unwrap();
+        let stream_contents = stream.to_vec().await;
+        assert_eq!(&stream_contents, b"helloworld");
+    }
+
+    #[tokio::test]
+    async fn write_and_rollback() {
+        let mut append_buffer = AppendBuffer::init().await.unwrap();
+
+        // write
+        let first_write = append_buffer.write("hello").await.unwrap();
+        assert_eq!(first_write.offset, 5);
+        assert_eq!(first_write.buffer_len, 5);
+        let second_write = append_buffer.write("world").await.unwrap();
+        assert_eq!(second_write.offset, 10);
+        assert_eq!(second_write.buffer_len, 10);
+
+        // rollback
+        let after_rollback = append_buffer.rollback(first_write.offset).await.unwrap();
+        assert_eq!(after_rollback.offset, 5);
+        assert_eq!(after_rollback.buffer_len, 0);
+
+        // read
+        let stream = append_buffer.read(after_rollback.offset).await.unwrap();
+        let stream_contents = stream.to_vec().await;
+        assert_eq!(&stream_contents, b"hello");
+    }
+
+    #[tokio::test]
+    async fn write_and_read_from_different_tasks() {
+        let mut append_buffer = AppendBuffer::init().await.unwrap();
+
+        // write
+        let append_buffer_moved = append_buffer.clone();
+        tokio::spawn(async move {
+            append_buffer_moved.write("hello").await.unwrap();
+            append_buffer_moved.write("world").await.unwrap();
+        })
+        .await
+        .unwrap();
+
+        // write
+        let append_buffer_moved = append_buffer.clone();
+        tokio::spawn(async move {
+            append_buffer_moved.write("foo").await.unwrap();
+            append_buffer_moved.write("bar").await.unwrap();
+        })
+        .await
+        .unwrap();
+
+        // read
+        let expected_contents = b"helloworldfoobar";
+        let stream = append_buffer.read(expected_contents.len()).await.unwrap();
+        let stream_contents = stream.to_vec().await;
+        assert_eq!(&stream_contents, expected_contents);
+    }
+}

--- a/broker/src/client/appender.rs
+++ b/broker/src/client/appender.rs
@@ -1,11 +1,12 @@
+use std::cmp::min;
+
 use tokio::sync::oneshot;
 use tokio_stream::{Stream, StreamExt};
 
 use protocol::extensions as pb_ext;
 use protocol::generated as pb;
 
-use crate::client::errors::ClientError;
-use crate::client::ClientResult;
+use crate::client::{ClientError, ClientResult};
 
 /// `Appender` adapts an `Append RPC` to the `Stream` trait. The first byte
 /// written to the `Appender` initiates the RPC. Subsequent bytes are streamed to
@@ -20,10 +21,10 @@ use crate::client::ClientResult;
 /// the append may or may commit.
 ///
 /// The application can cleanly roll-back a started `Appender` by `aborting` it.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Appender {
     rjc: pb_ext::RoutedJournalClient,
-    request: pb::AppendRequest,
+    pub(crate) request: pb::AppendRequest,
 }
 
 impl Appender {
@@ -42,7 +43,7 @@ impl Appender {
     }
 
     /// Append the contents of a `Stream` to a journal as a single Append transaction.
-    pub async fn append<S>(&mut self, stream: S) -> ClientResult<pb::AppendResponse>
+    pub async fn append<S>(&mut self, stream: StreamSection<S>) -> ClientResult<pb::AppendResponse>
     where
         S: Stream<Item = std::io::Result<bytes::Bytes>> + Send + Sync + 'static + Unpin,
     {
@@ -67,7 +68,7 @@ impl Appender {
     /// Create an async `Stream` that is consumed by an Append RPC.
     fn stream<S>(
         &self,
-        mut stream: S,
+        mut stream: StreamSection<S>,
         stream_err_tx: oneshot::Sender<ClientError>,
     ) -> impl Stream<Item = pb::AppendRequest>
     where
@@ -81,9 +82,9 @@ impl Appender {
 
             yield request; // Send append request metadata as first message.
             loop {
-                match stream.next().await {
+                match stream.inner.next().await {
                     None => {
-                        // Clean EOF of |reader|. Commit by sending empty AppendRequest, then close.
+                        // Clean EOF of |stream|. Commit by sending empty AppendRequest, then close.
                         yield pb::AppendRequest::default();
                         return;
                     }
@@ -92,8 +93,17 @@ impl Appender {
                             continue;
                         }
 
-                        // Send non-empty content to broker.
-                        yield pb::AppendRequest { content: content.to_vec(), ..Default::default() };
+                        match stream.read(content) {
+                            None => {
+                                // EOF of |stream| section. Commit by sending empty AppendRequest, then close.
+                                yield pb::AppendRequest::default();
+                                return;
+                            },
+                            Some(content) => {
+                                // Send non-empty content to broker.
+                                yield pb::AppendRequest { content, ..Default::default() };
+                            }
+                        }
                     }
                     Some(Err(err)) => {
                         // Internal error. Retain it, and return _without_ sending an empty AppendRequest.
@@ -104,5 +114,55 @@ impl Appender {
                 }
             }
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct StreamSection<S>
+where
+    S: Stream<Item = std::io::Result<bytes::Bytes>> + Send + Sync + 'static + Unpin,
+{
+    inner: S,
+    bytes_read: usize,
+    checkpoint: usize,
+}
+
+impl<S> StreamSection<S>
+where
+    S: Stream<Item = std::io::Result<bytes::Bytes>> + Send + Sync + 'static + Unpin,
+{
+    pub fn new(inner: S, checkpoint: usize) -> Self {
+        Self {
+            inner,
+            bytes_read: 0,
+            checkpoint,
+        }
+    }
+
+    fn read(&mut self, content: bytes::Bytes) -> Option<Vec<u8>> {
+        let n_to_read = min(content.len(), self.checkpoint - self.bytes_read);
+        if n_to_read == 0 {
+            // End of section
+            None
+        } else {
+            self.bytes_read += n_to_read;
+            Some(
+                content
+                    .get(..n_to_read)
+                    .expect("should have bytes in sub-range")
+                    .to_vec(),
+            )
+        }
+    }
+
+    #[cfg(test)]
+    pub async fn to_vec(mut self) -> Vec<u8> {
+        let mut stream_contents = Vec::new();
+        while let Some(chunk) = self.inner.next().await {
+            if let Some(chunk) = &self.read(chunk.unwrap()) {
+                stream_contents.extend_from_slice(chunk);
+            }
+        }
+        stream_contents
     }
 }

--- a/broker/src/client/errors.rs
+++ b/broker/src/client/errors.rs
@@ -8,6 +8,9 @@ pub type ClientResult<T> = Result<T, ClientError>;
 
 #[derive(Error, Debug)]
 pub enum ClientError {
+    #[error("operational error")]
+    Operational(String),
+
     #[error("gRPC error")]
     Grpc(tonic::Status),
 
@@ -24,7 +27,7 @@ pub enum ClientError {
     IO(#[from] std::io::Error),
 }
 
-mod third_party {
+mod third_party_errors {
     use super::*;
 
     impl From<tonic::Status> for ClientError {
@@ -47,6 +50,16 @@ mod third_party {
     impl From<tokio::sync::oneshot::error::RecvError> for ClientError {
         fn from(err: tokio::sync::oneshot::error::RecvError) -> Self {
             Self::Channel(err.to_string())
+        }
+    }
+}
+
+mod std_errors {
+    use super::*;
+
+    impl<W> From<std::io::IntoInnerError<W>> for ClientError {
+        fn from(err: std::io::IntoInnerError<W>) -> Self {
+            Self::IO(err.into_error())
         }
     }
 }

--- a/broker/src/client/errors.rs
+++ b/broker/src/client/errors.rs
@@ -62,4 +62,16 @@ mod std_errors {
             Self::IO(err.into_error())
         }
     }
+
+    impl<T> From<std::sync::mpsc::SendError<T>> for ClientError {
+        fn from(err: std::sync::mpsc::SendError<T>) -> Self {
+            Self::Channel(err.to_string())
+        }
+    }
+
+    impl From<std::sync::mpsc::RecvError> for ClientError {
+        fn from(err: std::sync::mpsc::RecvError) -> Self {
+            Self::Channel(err.to_string())
+        }
+    }
 }

--- a/broker/src/client/mod.rs
+++ b/broker/src/client/mod.rs
@@ -1,4 +1,4 @@
-use errors::{ClientError, ClientResult};
+use errors::ClientResult;
 
 mod append_service;
 pub mod appender;

--- a/broker/src/client/mod.rs
+++ b/broker/src/client/mod.rs
@@ -1,5 +1,6 @@
-use errors::ClientResult;
+use errors::{ClientError, ClientResult};
 
+mod append_service;
 pub mod appender;
 pub mod errors;
 mod retry;

--- a/broker/src/lib.rs
+++ b/broker/src/lib.rs
@@ -1,3 +1,5 @@
 #![allow(dead_code)]
 
+extern crate core;
+
 pub mod client;

--- a/broker/tests/appender.rs
+++ b/broker/tests/appender.rs
@@ -1,8 +1,10 @@
-use broker::client::appender::{Appender, StreamSection};
+use std::io::Write;
+use tokio::io::AsyncReadExt;
+
+use broker::client::appender::Appender;
 use broker::client::errors::ClientError;
 use protocol::extensions as pb_ext;
 use protocol::generated as pb;
-use std::io::Write;
 
 #[tokio::test]
 #[ignore]
@@ -35,9 +37,9 @@ async fn commits_successfully() {
         ..Default::default()
     };
     let mut file = tempfile::NamedTempFile::new().unwrap();
-    file.write_all(b"foo".as_slice()).unwrap();
-    let reader = tokio::fs::File::from(file.reopen().unwrap());
-    let stream = StreamSection::new(tokio_util::io::ReaderStream::new(reader), 3);
+    file.write_all(b"foobar".as_slice()).unwrap();
+    let reader = tokio::fs::File::from(file.reopen().unwrap()).take(3);
+    let stream = tokio_util::io::ReaderStream::new(reader);
     let mut appender = Appender::new(rjc, req).unwrap();
     let res = appender
         .append(stream)


### PR DESCRIPTION
**Description:**

Initial implementation of the [`AppendBuffer`](https://github.com/gazette/core/blob/master/broker/client/append_service.go#L424) with support for doing writes, rollbacks and reads using the underlying temp file. The API of this struct has been designed to follow the needs of the AppendService client code (doing writes) and the needs of the AsyncAppend internal code (rollbacks and reads), allowing concurrent use of the same temp file from both the AppendService and AsyncAppend using message passing.

Also, note that the `read` method returns the stream needed by the `Appender`. I had a test in `append_service` setting up a server and testing that the `Appender` can work with the stream returned by the `AppendBuffer`, but since it uses private stuff (like the `Appender` struct) I've deleted it. Where should I put this test? In `append_service_test.rs` to avoid making things public unnecessarily?

It will need to be extended when developing the `AsyncAppend` code (like adding an explicit flush method for example) but the foundations are there.

**Notes for reviewers:**

There is a [TODO](https://github.com/adrianbenavides/core-rs/compare/adrian/append-buffer?expand=1#diff-d1bb91c8449d6381d2f9db207aa6d56933539b7ef8f737721c5b0f9d300a2dcdR16) related to how to handle temporary files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/adrianbenavides/core-rs/2)
<!-- Reviewable:end -->
