### PR TITLE
feat: initial implementation of AppendService

### DIFF
--- a/broker/src/client/append_service.rs
+++ b/broker/src/client/append_service.rs
@@ -1,225 +1,561 @@
+use std::collections::HashMap;
 use std::io::prelude::*;
-use std::io::{BufWriter, SeekFrom};
-use std::sync::mpsc;
+use std::io::SeekFrom;
+use std::sync::Arc;
 
 use tokio::io::AsyncReadExt;
+use tokio::sync::{mpsc, oneshot, Mutex, OwnedMutexGuard};
 
+use append_buffer::*;
+use async_append::*;
+use protocol::extensions as pb_ext;
+use protocol::generated as pb;
+pub use service::*;
+
+use crate::client::appender::Appender;
 use crate::client::errors::{ClientError, ClientResult};
 
 const APPEND_BUFFER_SIZE: usize = 8 * 1024; // 8KB
+const APPEND_BUFFER_CUTOFF: usize = 64 * 1024 * 1024; // 64MB
 
-type SectionStream = tokio_util::io::ReaderStream<tokio::io::Take<tokio::fs::File>>;
+pub(crate) type SectionStream = tokio_util::io::ReaderStream<tokio::io::Take<tokio::fs::File>>;
+type WorkingAppendNode = (Arc<Mutex<AsyncAppendNode>>, OwnedMutexGuard<()>);
+
+/// AsyncJournalClient defines an API for performing asynchronous Append operations.
+#[async_trait::async_trait]
+trait AsyncJournalClient {
+    /// start_append begins a new asynchronous Append RPC. The caller holds exclusive access
+    /// to the returned AsyncAppend, and must then:
+    ///  * Write content to its Writer.
+    ///  * Optionally Require that one or more errors are nil.
+    ///  * Release the AsyncAppend, allowing queued writes to commit or,
+    ///    if an error occurred, to roll back.
+    ///
+    /// For performance reasons, an Append will often be batched with other Appends
+    /// having identical AppendRequests which are dispatched to this AppendService,
+    /// and note the Response.Fragment will reflect the entire batch written to the
+    /// broker. In all cases, relative order of Appends is preserved. One or more
+    /// dependencies may optionally be supplied. The Append RPC will not begin
+    /// until all dependencies have completed without error. A failure of a
+    /// dependency will also permanently fail the returned AsyncAppend and prevent
+    /// any further appends to this journal from starting. For this reason, a
+    /// Future should only fail if it also invalidates the AsyncJournalClient
+    /// (eg, because the client is scoped to a context which is invalidated by the
+    /// OpFuture failure).
+    async fn start_append(
+        &mut self,
+        request: pb::AppendRequest,
+        // TODO
+        // dependencies: Future,
+    ) -> ClientResult<WorkingAppendNode>;
+
+    // TODO
+    // (except: Journal) -> Vec<Future>;
+}
 
 #[derive(Debug)]
-struct AppendBuffer;
+#[allow(clippy::large_enum_variant)]
+enum JournalClientReq {
+    StartAppend {
+        res_tx: oneshot::Sender<ClientResult<WorkingAppendNode>>,
+        request: pb::AppendRequest,
+    },
+    RemoveJournal {
+        journal: pb_ext::Journal,
+    },
+    UpdateJournal {
+        journal: pb_ext::Journal,
+        shared_mutex: Arc<Mutex<()>>,
+        append: Arc<Mutex<AsyncAppendNode>>,
+    },
+}
 
-impl AppendBuffer {
-    pub fn init() -> ClientResult<AppendBufferHandle> {
-        // TODO: named temp files have some security concerns (see docs), should they be written outside of temp directories?
-        let file = tempfile::NamedTempFile::new()?;
-        let (req_tx, req_rx) = mpsc::channel::<AppendBufferReq>();
-        tokio::task::spawn_blocking(move || Self::handle_requests(file, req_rx));
-        Ok(AppendBufferHandle { req_tx })
+pub mod service {
+    use super::*;
+
+    type AppendsMapValue = (Arc<Mutex<()>>, Arc<Mutex<AsyncAppendNode>>);
+
+    /// AppendService batches, dispatches, and (if needed) retries asynchronous
+    /// Append RPCs. Use of an AppendService is appropriate for clients who make
+    /// large numbers of small writes to a Journal, and where those writes may be
+    /// pipelined and batched to amortize the cost of broker Append RPCs. It may
+    /// also simplify implementations for clients who would prefer to simply have
+    /// writes block until successfully committed, as opposed to handling errors
+    /// and retries themselves.
+    ///
+    /// For each journal, AppendService manages an ordered list of AsyncAppends,
+    /// each having buffered content to be appended. The list is dispatched in
+    /// FIFO order by a journal-specific goroutine.
+    ///
+    /// AsyncAppends are backed by temporary files on the local disk rather
+    /// than memory buffers. This minimizes the impact of buffering on the heap
+    /// and garbage collector, and also makes AppendService tolerant to sustained
+    /// service disruptions (up to the capacity of the disk).
+    ///
+    /// AppendService implements the AsyncJournalClient trait.
+    #[derive(Debug)]
+    pub struct AppendService {
+        client: pb_ext::RoutedJournalClient,
+        appends: HashMap<pb_ext::Journal, AppendsMapValue>,
+        // TODO
+        // errs: HashMap<pb_ext::Journal, ClientError>,
+        req_rx: mpsc::Receiver<JournalClientReq>,
+        req_tx: mpsc::Sender<JournalClientReq>,
     }
 
-    fn handle_requests(file: tempfile::NamedTempFile, req_rx: mpsc::Receiver<AppendBufferReq>) {
-        let mut offset = 0;
-        let mut writer = std::io::BufWriter::with_capacity(APPEND_BUFFER_SIZE, file);
-        while let Ok(op) = req_rx.recv() {
-            match op {
-                AppendBufferReq::Write { res_tx, buf } => {
-                    let _ = res_tx.send(Self::write(&mut writer, &mut offset, buf));
+    impl AppendService {
+        pub fn init(client: pb_ext::RoutedJournalClient) -> AppendServiceHandle {
+            // TODO: the buffer should match the expected number of concurrent clients?
+            let (req_tx, req_rx) = mpsc::channel(100);
+            let this = Self {
+                client,
+                appends: Default::default(),
+                req_rx,
+                req_tx: req_tx.clone(),
+            };
+            tokio::spawn(Self::handle(this));
+            AppendServiceHandle { req_tx }
+        }
+
+        async fn handle(mut this: Self) -> ClientResult<()> {
+            while let Some(req) = this.req_rx.recv().await {
+                match req {
+                    JournalClientReq::StartAppend { res_tx, request } => {
+                        let _ = res_tx.send(this.start_append(request).await);
+                    }
+                    JournalClientReq::RemoveJournal { journal } => {
+                        this.appends.remove(&journal);
+                    }
+                    JournalClientReq::UpdateJournal {
+                        journal,
+                        shared_mutex,
+                        append,
+                    } => {
+                        this.appends.insert(journal, (shared_mutex, append));
+                    }
                 }
-                AppendBufferReq::Rollback { res_tx, checkpoint } => {
-                    let _ = res_tx.send(Self::rollback(&mut writer, &mut offset, checkpoint));
+            }
+            Ok(())
+        }
+
+        async fn serve_appends(
+            req_tex: mpsc::Sender<JournalClientReq>,
+            shared_mutex: Arc<Mutex<()>>,
+            mut append_node: Arc<Mutex<AsyncAppendNode>>,
+        ) -> ClientResult<()> {
+            {
+                let _shared_lock = shared_mutex.lock().await;
+            }
+            let mut prev_append_node = append_node.clone();
+            loop {
+                {
+                    let _shared_lock = shared_mutex.lock().await;
+                    let mut append_node_lock = append_node.lock().await;
+                    // Termination condition: this |append_node| can be immediately resolved without
+                    // blocking, and no further appends are queued.
+                    if append_node_lock.next.is_none() && append_node_lock.inner.buf.is_none()
+                    // && async_append.dependencies.is_empty() // TODO
+                    {
+                        req_tex
+                            .send(JournalClientReq::RemoveJournal {
+                                journal: append_node_lock.inner.journal(),
+                            })
+                            .await?;
+                        // Mark |append_node| as completed.
+                        append_node_lock.next = Some(append_node.clone());
+                        return Ok(());
+                    }
+
+                    if append_node_lock.next.is_none() {
+                        let next = Arc::new(Mutex::new(append_node_lock.chain()?));
+                        append_node_lock.next = Some(next.clone());
+                        req_tex
+                            .send(JournalClientReq::UpdateJournal {
+                                journal: append_node_lock.inner.journal(),
+                                shared_mutex: shared_mutex.clone(),
+                                append: next,
+                            })
+                            .await?;
+                    }
                 }
-                AppendBufferReq::Read { res_tx, checkpoint } => {
-                    let _ = res_tx.send(Self::read(writer, checkpoint));
-                    break;
+
+                // Further appends may queue while we dispatch this RPC.
+                {
+                    let mut append_node_lock = append_node.lock().await;
+
+                    // TODO: loop dependencies
+                    // ...
+
+                    if append_node_lock.inner.buf.is_some() {
+                        let stream = append_node_lock.inner.read()?;
+                        append_node_lock.inner.appender.append(stream).await?;
+                    }
+                }
+
+                // Step |append_node| to |append_node.next|. While doing so, clear fields of prior |append_node|
+                // not required to represent its final response. This keeps retained
+                // AsyncAppends from pinning other resources from the garbage collector.
+                //
+                // Also set |append_node.next| to itself to denote this AsyncAppend as completed.
+                {
+                    let _shared_lock = shared_mutex.lock().await;
+                    let mut append_node_lock = append_node.lock().await;
+                    let next_append_node = append_node_lock
+                        .next
+                        .clone()
+                        .expect("next should be defined");
+                    append_node_lock.next = Some(prev_append_node.clone());
+                    // async_append_guard.dependencies = None; // TODO
+                    append_node_lock.inner.buf = None;
+                    drop(append_node_lock);
+                    prev_append_node = std::mem::replace(&mut append_node, next_append_node);
+                }
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AsyncJournalClient for AppendService {
+        async fn start_append(
+            &mut self,
+            request: pb::AppendRequest,
+        ) -> ClientResult<(Arc<Mutex<AsyncAppendNode>>, OwnedMutexGuard<()>)> {
+            // Fetch the current AsyncAppend for |journal|, or start one if none exists.
+            let (shared_mutex, mut append_node, is_new_journal) = {
+                match self.appends.get(&request.journal) {
+                    None => {
+                        let shared_mutex = Arc::new(Mutex::new(()));
+                        let append_node = Arc::new(Mutex::new(AsyncAppendNode {
+                            inner: AsyncAppend::new(self.client.clone(), request.clone())?,
+                            next: None,
+                        }));
+                        self.appends.insert(
+                            request.journal.clone(),
+                            (shared_mutex.clone(), append_node.clone()),
+                        );
+                        (shared_mutex, append_node, true)
+                    }
+                    Some((shared_mutex, append_node)) => {
+                        (shared_mutex.clone(), append_node.clone(), false)
+                    }
                 }
             };
+
+            // Acquire exclusive write access for |journal|. This may race with
+            // other writes in progress, and on mutex acquisition a different AsyncAppend
+            // may now be current for the journal.
+            let shared_lock = {
+                let shared_mutex = shared_mutex.clone();
+                shared_mutex.lock_owned().await
+            };
+
+            // Start the service loop (if needed) *after* we acquire |shared_mutex|, and
+            // *before* we skip forward to the current AsyncAppend. This ensures
+            // serveAppends starts from the first AsyncAppend of the chain, and
+            // that it blocks until the client completes the first write.
+            if is_new_journal {
+                let shared_mutex = shared_mutex.clone();
+                let append_node = append_node.clone();
+                let req_tx = self.req_tx.clone();
+                tokio::spawn(async move {
+                    Self::serve_appends(req_tx, shared_mutex, append_node).await
+                });
+            }
+
+            // Follow the chain to the current AsyncAppend.
+            loop {
+                let append_node_lock = append_node.lock().await;
+                match append_node_lock.next.clone() {
+                    None => {
+                        break;
+                    }
+                    Some(next) => {
+                        drop(append_node_lock);
+                        append_node = next;
+
+                        // It's possible that (while we were waiting for |shared_mutex|)
+                        // serveAppends completed this AsyncAppend, which it marked by setting
+                        // |append_node.next| to itself. Recurse to try again.
+                        let append_node_lock = append_node.lock().await;
+                        if let Some(next) = &append_node_lock.next {
+                            let next_append_node_lock = next.lock().await;
+                            if append_node_lock.inner == next_append_node_lock.inner {
+                                return self.start_append(request.clone()).await;
+                            }
+                        }
+                    }
+                }
+            }
+            {
+                // Chain a new Append RPC if this one is over a threshold size.
+                let mut append_node_lock = append_node.lock().await;
+                if append_node_lock.inner.checkpoint > APPEND_BUFFER_CUTOFF
+                    // Or has dependencies which are not a subset of |append_node|'s.
+                    // || !dependencies.IsSubsetOf(append_node.dependencies) // TODO
+                    // Or if the requests themselves differ.
+                    || request != append_node_lock.inner.appender.request
+                {
+                    let new = Arc::new(Mutex::new(append_node_lock.chain()?));
+                    append_node_lock.next = Some(new.clone());
+                    self.appends
+                        .insert(request.journal.clone(), (shared_mutex.clone(), new.clone()));
+                    drop(append_node_lock);
+                    append_node = new;
+                }
+            }
+            {
+                // Initialize append buffer if needed
+                let mut append_node_lock = append_node.lock().await;
+                if append_node_lock.inner.buf.is_none() {
+                    // This is the first time this AsyncAppend is being returned by
+                    // start_append. Initialize its buffer, which also signals that this
+                    // |append_node| has been returned by start_append, and that a client may be
+                    // waiting on its RPC response.
+                    append_node_lock.inner.buf =
+                        Some(AppendBuffer::new(append_node_lock.inner.journal())?);
+                }
+            }
+            Ok((append_node, shared_lock))
         }
     }
 
-    fn write(
-        writer: &mut BufWriter<tempfile::NamedTempFile>,
-        offset: &mut usize,
-        buf: bytes::Bytes,
-    ) -> ClientResult<AppendBufferStatus> {
-        writer.write_all(&buf)?;
-        *offset += buf.len();
-        Ok(AppendBufferStatus {
-            offset: *offset,
-            buffer_len: writer.buffer().len(),
-        })
+    #[derive(Debug, Clone)]
+    pub struct AppendServiceHandle {
+        req_tx: mpsc::Sender<JournalClientReq>,
     }
 
-    fn rollback(
-        writer: &mut BufWriter<tempfile::NamedTempFile>,
-        offset: &mut usize,
-        checkpoint: usize,
-    ) -> ClientResult<AppendBufferStatus> {
-        *offset = checkpoint;
-        writer.seek(SeekFrom::Start(*offset as u64))?; // Flush and seek
-        Ok(AppendBufferStatus {
-            offset: *offset,
-            buffer_len: writer.buffer().len(),
-        })
-    }
-
-    fn read(
-        writer: BufWriter<tempfile::NamedTempFile>,
-        checkpoint: usize,
-    ) -> ClientResult<SectionStream> {
-        // TODO: handle flush error as in https://github.com/gazette/core/blob/master/broker/client/append_service.go#L453
-        let reader = writer.into_inner()?.reopen()?; // Flush buffer into File and reopen to read contents.
-        let reader = tokio::fs::File::from(reader).take(checkpoint as u64);
-        let stream = tokio_util::io::ReaderStream::with_capacity(reader, APPEND_BUFFER_SIZE);
-        Ok(stream)
-    }
-}
-
-#[derive(Debug, Clone)]
-struct AppendBufferHandle {
-    req_tx: mpsc::Sender<AppendBufferReq>,
-}
-
-impl AppendBufferHandle {
-    fn write<B: Into<bytes::Bytes>>(&self, buf: B) -> ClientResult<AppendBufferStatus> {
-        let (res_tx, res_rx) = mpsc::channel::<ClientResult<AppendBufferStatus>>();
-        self.req_tx.send(AppendBufferReq::Write {
-            res_tx,
-            buf: buf.into(),
-        })?;
-        match res_rx.recv() {
-            Err(err) => Err(ClientError::from(err)),
-            Ok(res) => res,
-        }
-    }
-
-    fn rollback(&self, checkpoint: usize) -> ClientResult<AppendBufferStatus> {
-        let (res_tx, res_rx) = mpsc::channel::<ClientResult<AppendBufferStatus>>();
-        self.req_tx
-            .send(AppendBufferReq::Rollback { res_tx, checkpoint })?;
-        match res_rx.recv() {
-            Err(err) => Err(ClientError::from(err)),
-            Ok(res) => res,
-        }
-    }
-
-    fn read(&mut self, checkpoint: usize) -> ClientResult<SectionStream> {
-        let (res_tx, res_rx) = mpsc::channel::<ClientResult<SectionStream>>();
-        self.req_tx
-            .send(AppendBufferReq::Read { res_tx, checkpoint })?;
-        match res_rx.recv() {
-            Err(err) => Err(ClientError::from(err)),
-            Ok(res) => res,
+    impl AppendServiceHandle {
+        pub async fn start_append(
+            &self,
+            request: pb::AppendRequest,
+        ) -> ClientResult<(Arc<Mutex<AsyncAppendNode>>, OwnedMutexGuard<()>)> {
+            let (res_tx, res_rx) = oneshot::channel();
+            self.req_tx
+                .send(JournalClientReq::StartAppend { res_tx, request })
+                .await?;
+            match res_rx.await {
+                Err(err) => Err(ClientError::from(err)),
+                Ok(res) => res,
+            }
         }
     }
 }
 
-#[derive(Debug)]
-enum AppendBufferReq {
-    Write {
-        res_tx: mpsc::Sender<ClientResult<AppendBufferStatus>>,
-        buf: bytes::Bytes,
-    },
-    Rollback {
-        res_tx: mpsc::Sender<ClientResult<AppendBufferStatus>>,
-        checkpoint: usize,
-    },
-    Read {
-        res_tx: mpsc::Sender<ClientResult<SectionStream>>,
-        checkpoint: usize,
-    },
-}
-
-#[derive(Debug)]
-struct AppendBufferStatus {
-    offset: usize,
-    buffer_len: usize,
-}
-
-#[cfg(test)]
-mod tests {
+mod async_append {
     use super::*;
-    use tokio_stream::StreamExt;
 
-    #[tokio::test]
-    async fn write_and_read() {
-        let mut append_buffer = AppendBuffer::init().unwrap();
-
-        // write
-        let write = append_buffer.write("hello").unwrap();
-        assert_eq!(write.offset, 5);
-        assert_eq!(write.buffer_len, 5);
-        let write = append_buffer.write("world").unwrap();
-        assert_eq!(write.offset, 10);
-        assert_eq!(write.buffer_len, 10);
-
-        // read
-        let stream = append_buffer.read(write.offset).unwrap();
-        let stream_contents = read_stream_contents(stream).await;
-        assert_eq!(&stream_contents, b"helloworld");
+    #[derive(Debug)]
+    pub struct AsyncAppend {
+        pub appender: Appender,
+        pub checkpoint: usize,
+        pub buf: Option<AppendBuffer>,
     }
 
-    #[tokio::test]
-    async fn write_and_rollback() {
-        let mut append_buffer = AppendBuffer::init().unwrap();
-
-        // write
-        let first_write = append_buffer.write("hello").unwrap();
-        assert_eq!(first_write.offset, 5);
-        assert_eq!(first_write.buffer_len, 5);
-        let second_write = append_buffer.write("world").unwrap();
-        assert_eq!(second_write.offset, 10);
-        assert_eq!(second_write.buffer_len, 10);
-
-        // rollback
-        let after_rollback = append_buffer.rollback(first_write.offset).unwrap();
-        assert_eq!(after_rollback.offset, 5);
-        assert_eq!(after_rollback.buffer_len, 0);
-
-        // read
-        let stream = append_buffer.read(after_rollback.offset).unwrap();
-        let stream_contents = read_stream_contents(stream).await;
-        assert_eq!(&stream_contents, b"hello");
-    }
-
-    #[tokio::test]
-    async fn write_and_read_from_different_tasks() {
-        let mut append_buffer = AppendBuffer::init().unwrap();
-
-        // write
-        let append_buffer_moved = append_buffer.clone();
-        tokio::spawn(async move {
-            append_buffer_moved.write("hello").unwrap();
-            append_buffer_moved.write("world").unwrap();
-        })
-        .await
-        .unwrap();
-
-        // write
-        let append_buffer_moved = append_buffer.clone();
-        tokio::spawn(async move {
-            append_buffer_moved.write("foo").unwrap();
-            append_buffer_moved.write("bar").unwrap();
-        })
-        .await
-        .unwrap();
-
-        // read
-        let expected_contents = b"helloworldfoobar";
-        let stream = append_buffer.read(expected_contents.len()).unwrap();
-        let stream_contents = read_stream_contents(stream).await;
-        assert_eq!(&stream_contents, expected_contents);
-    }
-
-    async fn read_stream_contents(mut stream: SectionStream) -> Vec<u8> {
-        let mut stream_contents = Vec::new();
-        while let Some(chunk) = stream.next().await {
-            stream_contents.extend_from_slice(&chunk.unwrap());
+    impl AsyncAppend {
+        pub fn new(
+            client: pb_ext::RoutedJournalClient,
+            req: pb::AppendRequest,
+        ) -> ClientResult<Self> {
+            Ok(Self {
+                appender: Appender::new(client, req)?,
+                checkpoint: 0,
+                buf: None,
+            })
         }
-        stream_contents
+
+        pub fn journal(&self) -> pb_ext::Journal {
+            self.appender.request.journal.clone()
+        }
+
+        pub fn write<B: Into<bytes::Bytes>>(
+            &mut self,
+            contents: B,
+        ) -> ClientResult<AppendBufferStatus> {
+            match &mut self.buf {
+                None => Err(ClientError::Runtime("buffer not initialized".to_string())),
+                Some(buf) => buf.write(contents.into()),
+            }
+        }
+
+        pub fn release(
+            &mut self,
+            status: AppendBufferStatus,
+            shared_lock: OwnedMutexGuard<()>,
+        ) -> ClientResult<()> {
+            self.checkpoint = status.offset + status.buffer_len;
+            drop(shared_lock);
+            Ok(())
+        }
+
+        pub fn read(&mut self) -> ClientResult<SectionStream> {
+            match &mut self.buf {
+                None => Err(ClientError::Runtime("buffer not initialized".to_string())),
+                Some(buf) => buf.read(self.checkpoint),
+            }
+        }
+    }
+
+    impl PartialEq for AsyncAppend {
+        fn eq(&self, other: &Self) -> bool {
+            std::ptr::eq(self, other)
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct AsyncAppendNode {
+        pub inner: AsyncAppend,
+        pub next: Option<Arc<Mutex<Self>>>,
+    }
+
+    impl AsyncAppendNode {
+        pub fn chain(&self) -> ClientResult<Self> {
+            if self.next.is_some() {
+                panic!("next is Some")
+            }
+            Ok(Self {
+                inner: AsyncAppend {
+                    appender: self.inner.appender.clone(),
+                    checkpoint: 0,
+                    buf: None,
+                },
+                next: None,
+            })
+        }
+    }
+}
+
+mod append_buffer {
+    use crate::client::retry::retry_until_blocking;
+
+    use super::*;
+
+    /// AppendBuffer composes a backing File with a BufWriter, and additionally
+    /// tracks the offset through which the file is written.
+    #[derive(Debug)]
+    pub struct AppendBuffer {
+        writer: std::io::BufWriter<tempfile::NamedTempFile>,
+        offset: usize,
+        journal: Arc<pb_ext::Journal>,
+    }
+
+    impl AppendBuffer {
+        pub fn new(journal: pb_ext::Journal) -> ClientResult<Self> {
+            let file = tempfile::NamedTempFile::new()?;
+            Ok(Self {
+                writer: std::io::BufWriter::with_capacity(APPEND_BUFFER_SIZE, file),
+                offset: 0,
+                journal: Arc::new(journal),
+            })
+        }
+
+        pub fn write(&mut self, buf: bytes::Bytes) -> ClientResult<AppendBufferStatus> {
+            self.writer.write_all(&buf)?;
+            self.offset += buf.len();
+            Ok(AppendBufferStatus {
+                offset: self.offset,
+                buffer_len: self.writer.buffer().len(),
+            })
+        }
+
+        pub fn rollback(&mut self, checkpoint: usize) -> ClientResult<AppendBufferStatus> {
+            self.offset = checkpoint;
+            let journal = self.journal.clone();
+            retry_until_blocking(|| self.flush(), &journal, "failed to flush append buffer");
+            retry_until_blocking(
+                || {
+                    self.writer
+                        .get_mut()
+                        .seek(SeekFrom::Start(self.offset as u64))
+                        .map_err(ClientError::from)
+                },
+                &journal,
+                "failed to seek append buffer",
+            );
+            Ok(AppendBufferStatus {
+                offset: self.offset,
+                buffer_len: self.writer.buffer().len(),
+            })
+        }
+
+        pub fn read(&mut self, checkpoint: usize) -> ClientResult<SectionStream> {
+            let journal = self.journal.clone();
+            retry_until_blocking(|| self.flush(), &journal, "failed to flush append buffer");
+            let reader = retry_until_blocking(
+                || self.writer.get_ref().reopen().map_err(ClientError::from),
+                &journal,
+                "failed to reopen backing file",
+            );
+            let reader = tokio::fs::File::from(reader).take(checkpoint as u64);
+            let stream = tokio_util::io::ReaderStream::with_capacity(reader, APPEND_BUFFER_SIZE);
+            Ok(stream)
+        }
+
+        fn flush(&mut self) -> ClientResult<()> {
+            // TODO: handle flush error as in https://github.com/gazette/core/blob/master/broker/client/append_service.go#L453
+            self.writer.flush()?;
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct AppendBufferStatus {
+        pub offset: usize,
+        pub buffer_len: usize,
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use tokio_stream::StreamExt;
+
+        use super::*;
+
+        #[tokio::test]
+        async fn write_and_read() {
+            let mut append_buffer = AppendBuffer::new("journal".to_string()).unwrap();
+
+            // write
+            let write = append_buffer.write(bytes::Bytes::from("hello")).unwrap();
+            assert_eq!(write.offset, 5);
+            assert_eq!(write.buffer_len, 5);
+            let write = append_buffer.write(bytes::Bytes::from("world")).unwrap();
+            assert_eq!(write.offset, 10);
+            assert_eq!(write.buffer_len, 10);
+
+            // read
+            let stream = append_buffer.read(write.offset).unwrap();
+            let stream_contents = read_stream_contents(stream).await;
+            assert_eq!(&stream_contents, b"helloworld");
+        }
+
+        #[tokio::test]
+        async fn write_and_rollback() {
+            let mut append_buffer = AppendBuffer::new("journal".to_string()).unwrap();
+
+            // write
+            let first_write = append_buffer.write(bytes::Bytes::from("hello")).unwrap();
+            assert_eq!(first_write.offset, 5);
+            assert_eq!(first_write.buffer_len, 5);
+            let second_write = append_buffer.write(bytes::Bytes::from("world")).unwrap();
+            assert_eq!(second_write.offset, 10);
+            assert_eq!(second_write.buffer_len, 10);
+
+            // rollback
+            let after_rollback = append_buffer.rollback(first_write.offset).unwrap();
+            assert_eq!(after_rollback.offset, 5);
+            assert_eq!(after_rollback.buffer_len, 0);
+
+            // read
+            let stream = append_buffer.read(after_rollback.offset).unwrap();
+            let stream_contents = read_stream_contents(stream).await;
+            assert_eq!(&stream_contents, b"hello");
+        }
+
+        async fn read_stream_contents(mut stream: SectionStream) -> Vec<u8> {
+            let mut stream_contents = Vec::new();
+            while let Some(chunk) = stream.next().await {
+                stream_contents.extend_from_slice(&chunk.unwrap());
+            }
+            stream_contents
+        }
     }
 }

--- a/broker/src/client/appender.rs
+++ b/broker/src/client/appender.rs
@@ -20,10 +20,10 @@ use crate::client::ClientResult;
 /// the append may or may commit.
 ///
 /// The application can cleanly roll-back a started `Appender` by `aborting` it.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Appender {
     rjc: pb_ext::RoutedJournalClient,
-    request: pb::AppendRequest,
+    pub(crate) request: pb::AppendRequest,
 }
 
 impl Appender {

--- a/broker/src/client/errors.rs
+++ b/broker/src/client/errors.rs
@@ -8,8 +8,8 @@ pub type ClientResult<T> = Result<T, ClientError>;
 
 #[derive(Error, Debug)]
 pub enum ClientError {
-    #[error("operational error")]
-    Operational(String),
+    #[error("runtime error")]
+    Runtime(String),
 
     #[error("gRPC error")]
     Grpc(tonic::Status),

--- a/broker/src/client/mod.rs
+++ b/broker/src/client/mod.rs
@@ -1,6 +1,6 @@
 use errors::ClientResult;
 
-mod append_service;
+pub mod append_service;
 pub mod appender;
 pub mod errors;
 mod retry;

--- a/broker/tests/append_service.rs
+++ b/broker/tests/append_service.rs
@@ -1,0 +1,31 @@
+use protocol::extensions as pb_ext;
+use protocol::generated as pb;
+
+use broker::client::append_service::{AppendService, AppendServiceHandle};
+
+#[tokio::test]
+#[ignore]
+async fn append_to_same_journal_from_different_tasks() {
+    let client = pb::JournalClient::connect("http://localhost:8080")
+        .await
+        .expect("Connect to server");
+    let rjc = pb_ext::RoutedJournalClient::new(client);
+    let append_service = AppendService::init(rjc);
+    let req = pb::AppendRequest {
+        journal: "test/journal".to_string(),
+        ..Default::default()
+    };
+    tokio::join!(
+        do_append("hello".to_string(), append_service.clone(), req.clone()),
+        do_append("world".to_string(), append_service, req)
+    );
+    // Give some time for the append_service to finish.
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+}
+
+async fn do_append(msg: String, append_service: AppendServiceHandle, req: pb::AppendRequest) {
+    let (append, shared_lock) = append_service.start_append(req).await.unwrap();
+    let mut append = append.lock().await;
+    let status = append.inner.write(msg).unwrap();
+    append.inner.release(status, shared_lock).unwrap();
+}


### PR DESCRIPTION
**Description:**

Initial implementation of the [`AppendService`](https://github.com/gazette/core/blob/master/broker/client/append_service.go#L34) with the basic functionality to batch and dispatch lists of ordered `AsyncAppends`.

**Notes for reviewers:**

* The `AppendBuffer` has been simplified: there is no need for the `AppendBufferHandle` because the `AsyncAppend` is behind an `Arc<Mutex<>>`
* There is a bunch of TODO's for all the missing functionalities, like the `AppendService`'s `errors` hashmap, `dependencies`, `pending_except`